### PR TITLE
Fix formatting of "__init__.py"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Feel free to contribute! Happy to receive PRs.
         * also, has exclusive checks:
             * PEP8 for Jupyter notebooks:
             [https://github.com/coala/coala-bears/blob/master/bears/python/PEP8NotebookBear.py](https://github.com/coala/coala-bears/blob/master/bears/python/PEP8NotebookBear.py)
-            * __init__.py checker:
+            * `__init__.py` checker:
             [https://github.com/coala/coala-bears/blob/master/bears/python/PythonPackageInitBear.py](https://github.com/coala/coala-bears/blob/master/bears/python/PythonPackageInitBear.py)
     * prospector - Primary aim of Prospector is to be useful 'out of the box'. Wraps the [following tools](https://prospector.landscape.io/en/master/supported_tools.html):
     [https://github.com/landscapeio/prospector](https://github.com/landscapeio/prospector)


### PR DESCRIPTION
Double underscore in Markdown normally means strong emphasis, which not what we want here.