### PR TITLE
Add wildlint to Linters (General)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Feel free to contribute! Happy to receive PRs.
     [https://github.com/PyCQA/pylint](https://github.com/PyCQA/pylint)
     * flake8-bugbear - A plugin for flake8 finding likely bugs and design problems in your program. Contains warnings that don't belong in pyflakes and pycodestyle:
     [https://github.com/PyCQA/flake8-bugbear](https://github.com/PyCQA/flake8-bugbear)
+    * wildlint - Static checks for bug classes off-the-shelf linters (ruff/flake8/pylint) miss — dead argparse flags, str.replace-as-strip (removeprefix/removesuffix mixups), deep negative indexing, humanizer rounding rollover. Each rule distilled from a real upstream fix. Cross-language (Python/JS/TS/Go/Rust). [https://github.com/patchwright/wildlint](https://github.com/patchwright/wildlint)
     * vulture - Find dead code:
     [https://pypi.python.org/pypi/vulture](https://pypi.python.org/pypi/vulture)
     * pydiatra - Yet another static checker for Python code:


### PR DESCRIPTION
Adds **wildlint** under *Linters → General*, beside flake8-bugbear (same niche: bug classes the base linters miss).

wildlint is a precision linter for bug classes off-the-shelf linters (ruff/flake8/pylint) don't cover — the kind that look like ordinary, working code:

- dead argparse flags (option defined but its `dest` is never read)
- `str.replace(prefix, "")` meant as `removeprefix`/`removesuffix`
- deep negative indexing `s[-k]` → `IndexError`
- humanizer rounding rollover (`millify(999999)` → `'1000k'`)

Each rule is distilled from a **real upstream fix** (provenance-pinned), so the default tier is near-silent on mature, heavily-linted codebases (django/click/flask) by design — it's a low-false-positive tool, not a high-recall scanner. Cross-language: Python, JS, TS, Go, Rust (via ast-grep).

- Repo: https://github.com/patchwright/wildlint
- PyPI: https://pypi.org/project/wildlint/ (0.8.2)
- License: MIT
- pre-commit hook available

Happy to move it to a different section if there's a better fit. Thanks for curating this list.